### PR TITLE
Specify more specific base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:14-buster
 
 WORKDIR /app
 


### PR DESCRIPTION
`node:14` isn't tagged on all architectures. Use `node:14-buster` which is more widely tagged and is comparable to `14` (an alias for `14-stretch`)