### PR TITLE
Check for blacklisted IP ranges when resolving remote homeserver URL's

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1429,6 +1429,14 @@
       "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
       "dev": true
     },
+    "ip-range-check": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ip-range-check/-/ip-range-check-0.2.0.tgz",
+      "integrity": "sha512-oaM3l/3gHbLlt/tCWLvt0mj1qUaI+STuRFnUvARGCujK9vvU61+2JsDpmkMzR4VsJhuFXWWgeKKVnwwoFfzCqw==",
+      "requires": {
+        "ipaddr.js": "^1.0.1"
+      }
+    },
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "axios": "^0.21.1",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
+    "ip-range-check": "^0.2.0",
     "uuid": "^8.3.2",
     "winston": "^3.3.3"
   }

--- a/src/dnsUtils.js
+++ b/src/dnsUtils.js
@@ -1,0 +1,33 @@
+const dns = require('dns');
+
+function resolverFactory(resolverFn) {
+    return (domain) => new Promise((resolve, reject) => {
+        resolverFn(domain, (err, addresses) => {
+            if (err) {
+                if (err.errno === 'ENODATA' || err.errno === 'ENOTFOUND') {
+                    resolve([]);
+                    return;
+                }
+                reject(err);
+                return;
+            }
+            resolve(addresses);
+        });
+    });
+}
+
+const resolve6 = resolverFactory(dns.resolve6);
+const resolve4 = resolverFactory(dns.resolve4);
+
+async function resolve(domain) {
+    const v6Addresses = (await resolve6(domain)) || [];
+    const v4Addresses = (await resolve4(domain)) || [];
+    return [
+        ...v6Addresses,
+        ...v4Addresses,
+    ];
+}
+
+module.exports = {
+    resolve,
+};

--- a/tests/matrixUtils.tests.js
+++ b/tests/matrixUtils.tests.js
@@ -6,6 +6,14 @@ require('../src/logger');
 const expect = chai.expect;
 
 describe('matrixUtils', function() {
+    describe('isDomainBlacklisted', () => {
+        it('returns correct results', async() => {
+            expect(await matrixUtils.isDomainBlacklisted('matrix.org')).to.be.false;
+            expect(await matrixUtils.isDomainBlacklisted('172.16.0.1')).to.be.true;
+            expect(await matrixUtils.isDomainBlacklisted('::ffff:172.16.0.1')).to.be.true;
+        });
+    });
+
     describe('parseHostnameAndPort', function() {
         it('returns correct results', async () => {
             expect(matrixUtils.parseHostnameAndPort('matrix.org')).to.deep.equal({


### PR DESCRIPTION
To avoid poking any internal infra, when resolving remote homeserver URL's (using S2S discovery), check any hostnames against an IP range blacklist.