### PR TITLE
Don't ever raise in DNS resolver

### DIFF
--- a/src/dnsUtils.js
+++ b/src/dnsUtils.js
@@ -1,14 +1,10 @@
 const dns = require('dns');
 
 function resolverFactory(resolverFn) {
-    return (domain) => new Promise((resolve, reject) => {
+    return (domain) => new Promise((resolve) => {
         resolverFn(domain, (err, addresses) => {
             if (err) {
-                if (err.errno === 'ENODATA' || err.errno === 'ENOTFOUND') {
-                    resolve([]);
-                    return;
-                }
-                reject(err);
+                resolve([]);
                 return;
             }
             resolve(addresses);


### PR DESCRIPTION
If we can't find any addresses, we don't care for the error, we just want an empty result set in that case.