### PR TITLE
Ensure we always return a value for users in power level check

### DIFF
--- a/src/verify.js
+++ b/src/verify.js
@@ -38,7 +38,7 @@ async function getRoomPowerLevels(userId, req) {
     if (response && response.data && response.data.state) {
         try {
             const content = response.data.state.filter(o => o.type === 'm.room.power_levels')[0].content;
-            const userLevel = content.users[userId];
+            const userLevel = content.users[userId] || 0;
             delete content.users;
             return {
                 room: content,


### PR DESCRIPTION
It's zero, if no power.