### PR TITLE
Ensure any axios requests also run the blacklist code for any redirects

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -183,7 +183,7 @@ async function axiosGet(url, haveRedirectedTimes = null, headers = null) {
             // This was the fourth time following a redirect, abort
             throw new Error('Maximum amount of redirects reached.');
         }
-        return axiosGet(response.headers.location, redirects + 1);
+        return axiosGet(response.headers.location, redirects + 1, headers);
     }
     return response;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -164,7 +164,7 @@ async function axiosGet(url, haveRedirectedTimes = null, headers = null) {
     }
     const urlObj = new URL(url);
     if (await isDomainBlacklisted(urlObj.hostname)) {
-        throw new Error(`Refusing to call blacklisted hostname ${urlObj.hostname}`);
+        throw new Error(`Refusing to call blacklisted or unresolved hostname ${urlObj.hostname}`);
     }
     const response = await axios.get(
         url,
@@ -178,12 +178,12 @@ async function axiosGet(url, haveRedirectedTimes = null, headers = null) {
             },
         },
     );
-    if (response >= 300) {
+    if (response.status >= 300) {
         if (redirects >= 4) {
             // This was the fourth time following a redirect, abort
             throw new Error('Maximum amount of redirects reached.');
         }
-        return axiosGet(url, redirects + 1);
+        return axiosGet(response.headers.location, redirects + 1);
     }
     return response;
 }

--- a/src/verify.js
+++ b/src/verify.js
@@ -1,7 +1,6 @@
-const axios = require('axios');
 const logger = require('./logger');
 const matrixUtils = require('./matrixUtils');
-const {errorLogger, tryStringify} = require('./utils');
+const utils = require('./utils');
 
 require('dotenv').config();
 
@@ -23,16 +22,15 @@ async function getRoomPowerLevels(userId, req) {
     try {
         const url = `${homeserverUrl}/_synapse/admin/v1/rooms/${req.body.room_id}/state`;
         logger.log('debug', `Making request to: ${url}`, {requestId: req.requestId});
-        response = await axios.get(
+        response = await utils.axiosGet(
             url,
+            null,
             {
-                headers: {
-                    Authorization: `Bearer ${process.env.UVS_ACCESS_TOKEN}`,
-                },
+                Authorization: `Bearer ${process.env.UVS_ACCESS_TOKEN}`,
             },
         );
     } catch (error) {
-        errorLogger(error, req);
+        utils.errorLogger(error, req);
         return;
     }
     if (response && response.data && response.data.state) {
@@ -103,14 +101,9 @@ async function verifyOpenIDToken(req) {
     try {
         const url = `${homeserverUrl}/_matrix/federation/v1/openid/userinfo`;
         logger.log('debug', `Making request to: ${url}?access_token=redacted`, {requestId: req.requestId});
-        response = await axios.get(
-            `${url}?access_token=${req.body.token}`,
-            {
-                timeout: 10000,
-            },
-        );
+        response = await utils.axiosGet(`${url}?access_token=${req.body.token}`);
     } catch (error) {
-        errorLogger(error, req);
+        utils.errorLogger(error, req);
         return false;
     }
     if (response && response.data && response.data.sub) {
@@ -130,7 +123,7 @@ async function verifyOpenIDToken(req) {
         logger.log('debug', 'Successful token verification', {requestId: req.requestId});
         return response.data.sub;
     }
-    logger.log('debug', `Failed token verification: ${tryStringify(response)}`, {requestId: req.requestId});
+    logger.log('debug', `Failed token verification: ${utils.tryStringify(response)}`, {requestId: req.requestId});
     return false;
 }
 
@@ -140,16 +133,15 @@ async function verifyRoomMembership(userId, req) {
     try {
         const url = `${homeserverUrl}/_synapse/admin/v1/rooms/${req.body.room_id}/members`;
         logger.log('debug', `Making request to: ${url}`, {requestId: req.requestId});
-        response = await axios.get(
+        response = await utils.axiosGet(
             url,
+            null,
             {
-                headers: {
-                    Authorization: `Bearer ${process.env.UVS_ACCESS_TOKEN}`,
-                },
+                Authorization: `Bearer ${process.env.UVS_ACCESS_TOKEN}`,
             },
         );
     } catch (error) {
-        errorLogger(error, req);
+        utils.errorLogger(error, req);
         return false;
     }
     if (response && response.data && response.data.members) {

--- a/tests/matrixUtils.tests.js
+++ b/tests/matrixUtils.tests.js
@@ -6,14 +6,6 @@ require('../src/logger');
 const expect = chai.expect;
 
 describe('matrixUtils', function() {
-    describe('isDomainBlacklisted', () => {
-        it('returns correct results', async() => {
-            expect(await matrixUtils.isDomainBlacklisted('matrix.org')).to.be.false;
-            expect(await matrixUtils.isDomainBlacklisted('172.16.0.1')).to.be.true;
-            expect(await matrixUtils.isDomainBlacklisted('::ffff:172.16.0.1')).to.be.true;
-        });
-    });
-
     describe('parseHostnameAndPort', function() {
         it('returns correct results', async () => {
             expect(matrixUtils.parseHostnameAndPort('matrix.org')).to.deep.equal({

--- a/tests/routes.tests.js
+++ b/tests/routes.tests.js
@@ -1,8 +1,8 @@
-const axios = require('axios');
 const chai = require('chai');
 const mockedEnv = require('mocked-env');
 const sinon = require('sinon');
 const routes = require('../src/routes');
+const utils = require('../src/utils');
 
 require('../src/logger');
 
@@ -28,7 +28,7 @@ describe('routes', function() {
 
     describe('getHealth', function() {
         it('thumbs up', function() {
-            axiosStub = sinon.spy(axios, 'get');
+            axiosStub = sinon.stub(utils, 'axiosGet');
             let req = {};
             let res = {
                 send: sinon.spy(),
@@ -42,7 +42,7 @@ describe('routes', function() {
 
     describe('postVerifyUser', function() {
         it('calls S2S API OpenID userinfo endpoint', async function() {
-            axiosStub = sinon.spy(axios, 'get');
+            axiosStub = sinon.stub(utils, 'axiosGet');
             let req = {
                 body: {
                     token: 'foobar',
@@ -60,7 +60,7 @@ describe('routes', function() {
         });
 
         it('returns false on invalid token', async function () {
-            axiosStub = sinon.stub(axios, 'get').throws();
+            axiosStub = sinon.stub(utils, 'axiosGet').throws();
             let req = {
                 body: {
                     token: 'foobar',
@@ -76,7 +76,7 @@ describe('routes', function() {
         });
 
         it('returns true and user ID on valid token', async function () {
-            axiosStub = sinon.stub(axios, 'get').returns({data: {sub: '@user:synapse.local'}});
+            axiosStub = sinon.stub(utils, 'axiosGet').returns({data: {sub: '@user:synapse.local'}});
             let req = {
                 body: {
                     token: 'foobar',
@@ -107,7 +107,7 @@ describe('routes', function() {
             });
 
             it('verify user requires a matrix_server_name', async function() {
-                axiosStub = sinon.spy(axios, 'get');
+                axiosStub = sinon.stub(utils, 'axiosGet');
                 let req = {
                     body: {
                         token: 'foobar',
@@ -139,7 +139,7 @@ describe('routes', function() {
             });
 
             it('rejects if no token given', async function() {
-                axiosStub = sinon.spy(axios, 'get');
+                axiosStub = sinon.stub(utils, 'axiosGet');
                 let req = {
                     body: {
                         token: 'foobar',
@@ -158,7 +158,7 @@ describe('routes', function() {
             });
 
             it('rejects if wrong token given', async function() {
-                axiosStub = sinon.spy(axios, 'get');
+                axiosStub = sinon.stub(utils, 'axiosGet');
                 let req = {
                     body: {
                         token: 'foobar',
@@ -179,7 +179,7 @@ describe('routes', function() {
             });
 
             it('succeeds if right token given', async function() {
-                axiosStub = sinon.spy(axios, 'get');
+                axiosStub = sinon.stub(utils, 'axiosGet');
                 let req = {
                     body: {
                         token: 'foobar',
@@ -202,7 +202,7 @@ describe('routes', function() {
 
     describe('postVerifyUserInRoom', function() {
         it('calls Synapse admin API to verify room membership', async function() {
-            axiosStub = sinon.stub(axios, 'get').returns({data: {sub: '@user:synapse.local'}});
+            axiosStub = sinon.stub(utils, 'axiosGet').returns({data: {sub: '@user:synapse.local'}});
             let req = {
                 body: {
                     room_id: '!barfoo:synapse.local',
@@ -222,7 +222,7 @@ describe('routes', function() {
         });
 
         it('returns false on invalid token', async function() {
-            axiosStub = sinon.stub(axios, 'get').onFirstCall().returns({data: {sub: '@user:synapse.local'}});
+            axiosStub = sinon.stub(utils, 'axiosGet').onFirstCall().returns({data: {sub: '@user:synapse.local'}});
             axiosStub.onSecondCall().returns({data: {members: []}});
             let req = {
                 body: {
@@ -244,7 +244,7 @@ describe('routes', function() {
         });
 
         it('returns true and user ID on valid token', async function() {
-            axiosStub = sinon.stub(axios, 'get').onFirstCall().returns({data: {sub: '@user:synapse.local'}});
+            axiosStub = sinon.stub(utils, 'axiosGet').onFirstCall().returns({data: {sub: '@user:synapse.local'}});
             axiosStub.onSecondCall().returns({data: {members: ['@user:synapse.local']}});
             axiosStub.onThirdCall().returns({data: { state: [
                 {
@@ -327,7 +327,7 @@ describe('routes', function() {
             });
 
             it('verify user in room requires a matrix_server_name', async function() {
-                axiosStub = sinon.spy(axios, 'get');
+                axiosStub = sinon.stub(utils, 'axiosGet');
                 let req = {
                     body: {
                         room_id: '!foobar:domain.tld',
@@ -360,7 +360,7 @@ describe('routes', function() {
             });
 
             it('rejects if no token given', async function() {
-                axiosStub = sinon.spy(axios, 'get');
+                axiosStub = sinon.stub(utils, 'axiosGet');
                 let req = {
                     body: {
                         room_id: '!foobar:domain.tld',
@@ -380,7 +380,7 @@ describe('routes', function() {
             });
 
             it('rejects if wrong token given', async function() {
-                axiosStub = sinon.spy(axios, 'get');
+                axiosStub = sinon.stub(utils, 'axiosGet');
                 let req = {
                     body: {
                         room_id: '!foobar:domain.tld',
@@ -402,7 +402,7 @@ describe('routes', function() {
             });
 
             it('succeeds if right token given', async function() {
-                axiosStub = sinon.spy(axios, 'get');
+                axiosStub = sinon.stub(utils, 'axiosGet');
                 let req = {
                     body: {
                         room_id: '!foobar:domain.tld',

--- a/tests/utils.tests.js
+++ b/tests/utils.tests.js
@@ -28,6 +28,30 @@ describe('matrixUtils', function() {
             expect(axiosStub.called).to.be.false;
         });
 
+it('ensures redirection domain is not blacklisted', async() => {
+    axiosStub = sinon.stub(axios, 'get');
+                                                                 
+    axiosStub.onFirstCall().returns({
+        headers: {
+            location: 'http://127.0.0.1',
+        },
+        status: 301,
+    });
+    axiosStub.onSecondCall().returns({status: 200});
+                                                                 
+    let raised;
+    try {
+        await utils.axiosGet('https://matrix.org');
+        raised = false;
+    } catch (error) {
+        raised = true;
+    }
+                                                                 
+    expect(raised).to.be.true;
+    expect(axiosStub.calledOnce).to.be.true;
+    expect(axiosStub.calledTwice).to.be.false;
+});
+
         it('calls axios', async() => {
             axiosStub = sinon.stub(axios, 'get');
             try {

--- a/tests/utils.tests.js
+++ b/tests/utils.tests.js
@@ -1,0 +1,16 @@
+const chai = require('chai');
+const utils = require('../src/utils');
+
+require('../src/logger');
+
+const expect = chai.expect;
+
+describe('matrixUtils', function() {
+    describe('isDomainBlacklisted', () => {
+        it('returns correct results', async() => {
+            expect(await utils.isDomainBlacklisted('matrix.org')).to.be.false;
+            expect(await utils.isDomainBlacklisted('172.16.0.1')).to.be.true;
+            expect(await utils.isDomainBlacklisted('::ffff:172.16.0.1')).to.be.true;
+        });
+    });
+});

--- a/tests/utils.tests.js
+++ b/tests/utils.tests.js
@@ -1,4 +1,6 @@
+const axios = require('axios');
 const chai = require('chai');
+const sinon = require('sinon');
 const utils = require('../src/utils');
 
 require('../src/logger');
@@ -6,6 +8,67 @@ require('../src/logger');
 const expect = chai.expect;
 
 describe('matrixUtils', function() {
+    describe('axiosGet', () => {
+        let axiosStub;
+
+        afterEach(() => {
+            axiosStub.restore();
+        });
+
+        it('ensures domain is not blacklisted', async() => {
+            axiosStub = sinon.stub(axios, 'get');
+            let raised;
+            try {
+                await utils.axiosGet('http://127.0.0.1');
+                raised = false;
+            } catch (error) {
+                raised = true;
+            }
+            expect(raised).to.be.true;
+            expect(axiosStub.called).to.be.false;
+        });
+
+        it('calls axios', async() => {
+            axiosStub = sinon.stub(axios, 'get');
+            try {
+                await utils.axiosGet('https://matrix.org');
+            } catch (error) {
+                // pass
+            }
+            expect(axiosStub.called).to.be.true;
+        });
+
+        it('calls axios twice on a redirect', async() => {
+            axiosStub = sinon.stub(axios, 'get');
+            axiosStub.onFirstCall().returns({
+                headers: {
+                    location: 'https://matrix.to',
+                },
+                status: 301,
+            });
+            axiosStub.onSecondCall().returns({status: 200});
+            try {
+                await utils.axiosGet('https://matrix.org');
+            } catch (error) {
+                // pass
+            }
+            expect(axiosStub.firstCall.args[0]).to.equal('https://matrix.org');
+            expect(axiosStub.secondCall.args[0]).to.equal('https://matrix.to');
+        });
+
+        it('returns a response', async() => {
+            axiosStub = sinon.stub(axios, 'get').returns({status: 200});
+            let response;
+            try {
+                response = await utils.axiosGet('https://matrix.org');
+            } catch (error) {
+                // pass
+            }
+            expect(axiosStub.called).to.be.true;
+            expect(response).to.deep.equal({status: 200});
+        });
+    });
+
     describe('isDomainBlacklisted', () => {
         it('returns correct results', async() => {
             expect(await utils.isDomainBlacklisted('matrix.org')).to.be.false;

--- a/tests/verify.tests.js
+++ b/tests/verify.tests.js
@@ -1,8 +1,8 @@
-const axios = require('axios');
 const chai = require('chai');
 const matrixUtils = require('../src/matrixUtils');
 const mockedEnv = require('mocked-env');
 const sinon = require('sinon');
+const utils = require('../src/utils');
 const verify = require('../src/verify');
 
 require('../src/logger');
@@ -29,7 +29,7 @@ describe('verify', function() {
         });
 
         it('calls configured homeserver with token', async () => {
-            axiosStub = sinon.stub(axios, 'get').returns({data: {sub: '@user:127.0.0.1'}});
+            axiosStub = sinon.stub(utils, 'axiosGet').returns({data: {sub: '@user:127.0.0.1'}});
             let req = {
                 body: {
                     token: 'token',
@@ -63,7 +63,7 @@ describe('verify', function() {
             });
 
             it('calls configured homeserver with token', async () => {
-                axiosStub = sinon.stub(axios, 'get').returns({data: {'sub': '@user:domain.tld'}});
+                axiosStub = sinon.stub(utils, 'axiosGet').returns({data: {'sub': '@user:domain.tld'}});
                 discoverHomeserverUrlStub = sinon.stub(matrixUtils, 'discoverHomeserverUrl').returns(
                     Promise.resolve({
                         homeserverUrl: 'http://domain.tld',
@@ -86,7 +86,7 @@ describe('verify', function() {
             });
 
             it('returns false if openid token subject does not match given matrix server name', async () => {
-                axiosStub = sinon.stub(axios, 'get').returns({data: {'sub': '@user:another.domain.tld'}});
+                axiosStub = sinon.stub(utils, 'axiosGet').returns({data: {'sub': '@user:another.domain.tld'}});
                 discoverHomeserverUrlStub = sinon.stub(matrixUtils, 'discoverHomeserverUrl').returns(
                     Promise.resolve({
                         homeserverUrl: 'http://domain.tld',


### PR DESCRIPTION
Wrap axios.get in our own function with logic to check each redirect again the domain blacklist code.

To keep code more simple, do this consistently for all axios requests, even if calling the configured homeserver.

Moves the isDomainBlacklisted to utils.js.