### PR TITLE
Refactor OpenID check behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,26 @@
 
 ## unreleased
 
-### Added
+### Breaking changes
 
-* Possibility to allow verifying any Matrix homeserver OpenID token. Default is still to
-  only verify tokens against the configured homeserver. Room membership verification
-  is still only done against the configured homeserver even if the token is for a user
-  on another homeserver. ([related issue](https://github.com/matrix-org/matrix-user-verification-service/issues/3))
+* Default behaviour has been changed to verify any OpenID tokens of any homeserver.
+  Room membership verification is still only done against the configured homeserver 
+  even if the token is for a user on another homeserver. 
+  ([related issue](https://github.com/matrix-org/matrix-user-verification-service/issues/3))
+  
+  To disable this and allow verifying only a single configured homeserver, set
+  the environment variable `UVS_OPENID_VERIFY_SERVER_NAME` to the relevant
+  Matrix server name (for example `matrix.org`).
+  
+  If upgrading from v1.1.0, to keep the same behaviour, one should set
+  `UVS_OPENID_VERIFY_SERVER_NAME` to the Matrix server name of the homeserver
+  behind `UVS_HOMESERVER_URL`.
+  
+  Due to this addition, `matrix_server_name` is a new required field in verify endpoints.
+  To not break backwards compatibility, this won't be enforced until earliest
+  in the next major version.
+
+### Added
   
 * Added authentication token to protect the verification API's.
 

--- a/README.md
+++ b/README.md
@@ -23,41 +23,44 @@ npm install
 Copy the default `.env.default` to `.env` and modify as needed.
 
 ```
-# Homeserver admin token (synapse only)
+## REQUIRED
+# Homeserver client API admin token (synapse only)
 # Required for the service to verify room membership
 UVS_ACCESS_TOKEN=foobar
-# Homeserver URL
+# Homeserver client API URL
 UVS_HOMESERVER_URL=https://matrix.org
-# (Optional) auth token to protect the API
+
+## OPTIONAL
+# Auth token to protect the API
 # If this is set any calls to the provided API endpoints
 # need have the header "Authorization: Bearer changeme".
 UVS_AUTH_TOKEN=changeme
-# (Optional) listen address of the bot
+# Matrix server name to verify OpenID tokens against. See below section.
+# Defaults to empty value which means verification is made against
+# whatever Matrix server name passed in with the token.
+UVS_OPENID_VERIFY_SERVER_NAME=matrix.org
+# Listen address of the bot
 UVS_LISTEN_ADDRESS=127.0.0.1
-# (Optional) listen port of the bot
+# Listen port of the bot
 UVS_PORT=3000
-# (Optional) log level, defaults to 'info'
+# Log level, defaults to 'info'
 # See choices here: https://github.com/winstonjs/winston#logging-levels
 UVS_LOG_LEVEL=info
-# (Optional) multiple homeserver mode, defaults to disabled
-# See below for more info.
-UVS_OPENID_VERIFY_ANY_HOMESERVER=false
 ```
 
 #### OpenID token verification
 
 UVS can run in a single homeserver mode or be configured to trust any
-homeserver OpenID token. Default is to only trust the configured homeserver
-OpenID tokens.
+homeserver OpenID token. Default is to trust the any Matrix server name
+that is given with the OpenID token.
 
-To enable multiple homeserver mode:
+To disable this and ensure only OpenID tokens from a single Matrix homeserver
+will be trusted, set the homeserver Matrix server name in the variable
+`UVS_OPENID_VERIFY_SERVER_NAME`. Note, this is the server name of the homeserver,
+not the client or federation API's domain.
 
-    UVS_OPENID_VERIFY_ANY_HOMESERVER=true
-
-Note, room membership is still limited to only the configured `UVS_HOMESERVER_URL`.
-
-When running with the multiple homeserver mode, `matrix_server_name` becomes
-a required request body item for all `/verify` verification API requests.
+Room membership is still currently limited to be verified from a single
+configured homeserver client API via `UVS_HOMESERVER_CLIENT_API_URL`.
 
 ### API's available
 
@@ -75,15 +78,6 @@ Verifies a user OpenID token.
     Content-Type: application/json
 
 Request body:
-
-```json
-{
-  "token": "secret token"
-}
-```
-
-If `UVS_OPENID_VERIFY_ANY_HOMESERVER` is set to `true`, the API also
-requires a `matrix_server_name`, becoming:
 
 ```json
 {
@@ -122,16 +116,6 @@ Verifies a user OpenID token and membership in a room.
     Content-Type: application/json
 
 Request body:
-
-```json
-{
-  "room_id": "!foobar:domain.tld",
-  "token": "secret token"
-}
-```
-
-If `UVS_OPENID_VERIFY_ANY_HOMESERVER` is set to `true`, the API also
-requires a `matrix_server_name`, becoming:
 
 ```json
 {

--- a/src/routes.js
+++ b/src/routes.js
@@ -22,7 +22,8 @@ const routes = {
             return;
         }
         const fields = ['token'];
-        if (process.env.UVS_OPENID_VERIFY_ANY_HOMESERVER === 'true') {
+        // TODO This check can be removed in 3.0, making `matrix_server_name` just required always.
+        if (!process.env.UVS_OPENID_VERIFY_SERVER_NAME) {
             fields.push('matrix_server_name');
         }
         const checkResult = sanityCheckRequest(req, res, fields);
@@ -52,7 +53,8 @@ const routes = {
             return;
         }
         const fields = ['token', 'room_id'];
-        if (process.env.UVS_OPENID_VERIFY_ANY_HOMESERVER === 'true') {
+        // TODO This check can be removed in 3.0, making `matrix_server_name` just required always.
+        if (!process.env.UVS_OPENID_VERIFY_SERVER_NAME) {
             fields.push('matrix_server_name');
         }
         const checkResult = sanityCheckRequest(req, res, fields);

--- a/src/verify.js
+++ b/src/verify.js
@@ -97,11 +97,11 @@ async function verifyOpenIDToken(req) {
     try {
         homeserver = await matrixUtils.discoverHomeserverUrl(serverName);
     } catch (error) {
-        logger.log('debug', `Failed to discover homeserver URL: ${error}`, {requestId: req.requestId});
+        logger.log('warn', `Failed to discover homeserver URL: ${error}`, {requestId: req.requestId});
         return false;
     }
     if (!homeserver.homeserverUrl) {
-        logger.log('debug',
+        logger.log('warn',
             'Empty or invalid homeserverUrl from discoverHomeserverUrl response',
             {requestId: req.requestId},
         );
@@ -123,7 +123,7 @@ async function verifyOpenIDToken(req) {
     }
     if (response && response.data && response.data.sub) {
         // Ensure the user ID actually matches the server name we checked against
-        if (!response.data.sub.endsWith(`:${serverName}`)) {
+        if (typeof response.data.sub !== 'string' || !response.data.sub.endsWith(`:${serverName}`)) {
             // This does not match, fail
             logger.log(
                 'warn',

--- a/tests/verify.tests.js
+++ b/tests/verify.tests.js
@@ -11,11 +11,20 @@ const expect = chai.expect;
 
 describe('verify', function() {
     let axiosStub;
+    let matrixUtilsStub;
     let originalEnv;
 
     before(() => {
         originalEnv = mockedEnv({
-            UVS_HOMESERVER_URL: 'http://127.0.0.1',
+            UVS_HOMESERVER_URL: 'http://synapse.local',
+        });
+    });
+
+    beforeEach(() => {
+        matrixUtilsStub = sinon.stub(matrixUtils, 'discoverHomeserverUrl');
+        matrixUtilsStub.onFirstCall().returns({
+            homeserverUrl: 'https://synapse.local',
+            serverName: 'synapse.local',
         });
     });
 
@@ -23,34 +32,64 @@ describe('verify', function() {
         originalEnv();
     });
 
-    describe('verifyOpenIDToken', function() {
-        afterEach(function() {
+    afterEach(function() {
+        try {
             axiosStub.restore();
-        });
+        // eslint-disable-next-line no-empty
+        } catch (error) {}
+        try {
+            matrixUtilsStub.restore();
+        // eslint-disable-next-line no-empty
+        } catch (error) {}
+    });
 
+    describe('verifyOpenIDToken', function() {
         it('calls configured homeserver with token', async () => {
-            axiosStub = sinon.stub(utils, 'axiosGet').returns({data: {sub: '@user:127.0.0.1'}});
+            axiosStub = sinon.stub(utils, 'axiosGet').returns({data: {'sub': '@user:domain.tld'}});
+            matrixUtilsStub.onFirstCall().returns({
+                homeserverUrl: 'https://domain.tld',
+                serverName: 'domain.tld',
+            });
+
             let req = {
                 body: {
+                    matrix_server_name: 'domain.tld',
                     token: 'token',
                 },
             };
             const response = await verify.verifyOpenIDToken(req);
 
-            expect(response).to.equal('@user:127.0.0.1');
+            expect(response).to.equal('@user:domain.tld');
             expect(axiosStub.calledOnce).to.be.true;
             expect(axiosStub.firstCall.args[0]).to.include(
-                'http://127.0.0.1/_matrix/federation/v1/openid/userinfo?access_token=token',
+                'https://domain.tld/_matrix/federation/v1/openid/userinfo?access_token=token',
             );
         });
 
-        describe('multiple homeserver mode', () => {
-            let discoverHomeserverUrlStub;
+        it('returns false if openid token subject does not match given matrix server name', async () => {
+            axiosStub = sinon.stub(utils, 'axiosGet').returns({data: {'sub': '@user:domain.tld'}});
+
+            let req = {
+                body: {
+                    matrix_server_name: 'synapse.local',
+                    token: 'token',
+                },
+            };
+            const response = await verify.verifyOpenIDToken(req);
+
+            expect(response).to.be.false;
+            expect(axiosStub.calledOnce).to.be.true;
+            expect(axiosStub.firstCall.args[0]).to.include(
+                'https://synapse.local/_matrix/federation/v1/openid/userinfo?access_token=token',
+            );
+        });
+
+        describe('single homeserver mode', () => {
             let originalEnv;
 
             before(() => {
                 originalEnv = mockedEnv({
-                    UVS_OPENID_VERIFY_ANY_HOMESERVER: 'true',
+                    UVS_OPENID_VERIFY_SERVER_NAME: 'matrix.org',
                 });
             });
 
@@ -58,54 +97,17 @@ describe('verify', function() {
                 originalEnv();
             });
 
-            afterEach(function() {
-                discoverHomeserverUrlStub.restore();
-            });
-
-            it('calls configured homeserver with token', async () => {
-                axiosStub = sinon.stub(utils, 'axiosGet').returns({data: {'sub': '@user:domain.tld'}});
-                discoverHomeserverUrlStub = sinon.stub(matrixUtils, 'discoverHomeserverUrl').returns(
-                    Promise.resolve({
-                        homeserverUrl: 'http://domain.tld',
-                    }),
-                );
-
+            it('does not call any other homeserver', async function() {
+                axiosStub = sinon.stub(utils, 'axiosGet');
                 let req = {
                     body: {
-                        matrix_server_name: 'domain.tld',
-                        token: 'token',
+                        matrix_server_name: 'synapse.local',
+                        token: 'foobar',
                     },
                 };
                 const response = await verify.verifyOpenIDToken(req);
-
-                expect(response).to.equal('@user:domain.tld');
-                expect(axiosStub.calledOnce).to.be.true;
-                expect(axiosStub.firstCall.args[0]).to.include(
-                    'http://domain.tld/_matrix/federation/v1/openid/userinfo?access_token=token',
-                );
-            });
-
-            it('returns false if openid token subject does not match given matrix server name', async () => {
-                axiosStub = sinon.stub(utils, 'axiosGet').returns({data: {'sub': '@user:another.domain.tld'}});
-                discoverHomeserverUrlStub = sinon.stub(matrixUtils, 'discoverHomeserverUrl').returns(
-                    Promise.resolve({
-                        homeserverUrl: 'http://domain.tld',
-                    }),
-                );
-
-                let req = {
-                    body: {
-                        matrix_server_name: 'domain.tld',
-                        token: 'token',
-                    },
-                };
-                const response = await verify.verifyOpenIDToken(req);
-
                 expect(response).to.be.false;
-                expect(axiosStub.calledOnce).to.be.true;
-                expect(axiosStub.firstCall.args[0]).to.include(
-                    'http://domain.tld/_matrix/federation/v1/openid/userinfo?access_token=token',
-                );
+                expect(axiosStub.calledOnce).to.be.false;
             });
         });
     });


### PR DESCRIPTION
Default behaviour has been changed to verify any OpenID tokens of any homeserver. This keeps the code, configuration and examples simpler by reversing to requiring configuring a single homeserver for OpenID verifications explicitly.

Additionally this allows for the server and client Matrix API's to be on different domains, which was not true before when running against a single homeserver.

This is a breaking change which has been highlighted in the changelog.

This PR also fixes verifying tokens against homeservers which use SRV to delegate to another domain.