### PR TITLE
Fallback to users_default if no power level is set

### DIFF
--- a/src/verify.js
+++ b/src/verify.js
@@ -37,7 +37,7 @@ async function getRoomPowerLevels(userId, req) {
         try {
             const content = response.data.state.filter(o => o.type === 'm.room.power_levels')[0].content;
             let userLevel = content.users[userId];
-            if (userLevel === undefined) {
+            if (!Number.isFinite(userLevel)) {
                 userLevel = content.users_default || 0;
             }
             delete content.users;

--- a/src/verify.js
+++ b/src/verify.js
@@ -36,7 +36,10 @@ async function getRoomPowerLevels(userId, req) {
     if (response && response.data && response.data.state) {
         try {
             const content = response.data.state.filter(o => o.type === 'm.room.power_levels')[0].content;
-            const userLevel = content.users[userId] || 0;
+            let userLevel = content.users[userId];
+            if (userLevel === undefined) {
+                userLevel = content.users_default || 0;
+            }
             delete content.users;
             return {
                 room: content,


### PR DESCRIPTION
When there is no explicit power level set for a user it should fallback to the value set in users_default.

Signed-off-by: Steffen Kolmer steffen.kolmer@nordeck.net