### PR TITLE
Skip manually generating ipv4-in-ipv6 ranges

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -112,12 +112,9 @@ const ip6RangeBlacklist = [
     'fec0::/10',
 ];
 
-const ip6FromIp4Blacklist = ip4RangeBlacklist.map(a => `::ffff:${a}`);
-
 const ipRangeBlacklist = [
     ...ip4RangeBlacklist,
     ...ip6RangeBlacklist,
-    ...ip6FromIp4Blacklist,
 ];
 
 /**

--- a/tests/utils.tests.js
+++ b/tests/utils.tests.js
@@ -98,6 +98,7 @@ it('ensures redirection domain is not blacklisted', async() => {
             expect(await utils.isBlacklisted('8.8.8.8')).to.be.false;
             expect(await utils.isBlacklisted(['172.16.0.1'])).to.be.true;
             expect(await utils.isBlacklisted(['::ffff:172.16.0.1'])).to.be.true;
+            expect(await utils.isBlacklisted(['::ffff:8.8.8.8'])).to.be.false;
         });
     });
 


### PR DESCRIPTION
We have the issue that some IPv6s were rejected by the filter, because of how the `::ffff:*` IPs are defined. The concatenation in `ip6FromIp4Blacklist` led to entries such as `::ffff:127.0.0.0/8`, which meant that all v6 IPs that start with 0x00 would be rejected (which applies to some used in our environment). The `ipaddr.js` library actually has [native support](https://github.com/whitequark/ipaddr.js/blob/760416b27a4b348e7a39fdacfccd6cb047026c98/src/ipaddr.coffee#L589-L590) for `::ffff:*` and converts them to IPv4 addresses on parsing so the entries from `ip6FromIp4Blacklist` are actually not used for matching.

I added an additional test case to make sure the filter is correct.