### PR TITLE
Made UVS_DISABLE_IP_BLACKLIST global

### DIFF
--- a/src/matrixUtils.js
+++ b/src/matrixUtils.js
@@ -1,5 +1,6 @@
 const net = require('net');
 const utils = require('./utils');
+const logger = require('./logger');
 const { Resolver } = require('dns').promises;
 
 const resolver = new Resolver();
@@ -99,7 +100,7 @@ async function discoverHomeserverUrl(serverName) {
         response = await utils.axiosGet(`https://${hostname}/.well-known/matrix/server`);
         delegatedHostname = response.data && response.data['m.server'];
     } catch (e) {
-        // Pass
+        logger.log('debug', `Failed to fetch .well-known: ${e}`);
     }
     if (delegatedHostname) {
         const parsed = parseHostnameAndPort(delegatedHostname);

--- a/src/utils.js
+++ b/src/utils.js
@@ -127,6 +127,7 @@ const ipRangeBlacklist = [
  * @returns {boolean}                   true if blacklisted
  */
 function isBlacklisted(addresses) {
+    if (process.env.UVS_DISABLE_IP_BLACKLIST === 'true') return false;
     return Array.from(addresses).some(a => ipRangeCheck(a, ipRangeBlacklist));
 }
 
@@ -161,14 +162,14 @@ function isBlacklisted(addresses) {
  * @returns {Promise<object>}                   Response object
  * @throws                                      On non-20x response (after redirects) or a blacklisted domain
  */
-async function axiosGet(url, haveRedirectedTimes = null, headers = null, disableBlacklistCheck = false) {
+async function axiosGet(url, haveRedirectedTimes = null, headers = null) {
     let redirects = haveRedirectedTimes;
     if (!redirects) {
         redirects = 0;
     }
     const urlObj = new URL(url);
 
-    if (!disableBlacklistCheck && isBlacklisted(await resolveDomain(urlObj.hostname))) {
+    if (isBlacklisted(await resolveDomain(urlObj.hostname))) {
         throw new Error(`Refusing to call blacklisted hostname ${urlObj.hostname}`);
     }
     const response = await axios.get(

--- a/src/verify.js
+++ b/src/verify.js
@@ -27,8 +27,7 @@ async function getRoomPowerLevels(userId, req) {
             null,
             {
                 Authorization: `Bearer ${process.env.UVS_ACCESS_TOKEN}`,
-            },
-            process.env.UVS_DISABLE_IP_BLACKLIST === 'true',
+            }
         );
     } catch (error) {
         utils.errorLogger(error, req);
@@ -155,8 +154,7 @@ async function verifyRoomMembership(userId, req) {
             null,
             {
                 Authorization: `Bearer ${process.env.UVS_ACCESS_TOKEN}`,
-            },
-            process.env.UVS_DISABLE_IP_BLACKLIST === 'true',
+            }
         );
     } catch (error) {
         utils.errorLogger(error, req);


### PR DESCRIPTION
Right now there is no way to use the service when matrix is on the local network and it's domain resolves to some address from a blacklisted range.
This applies UVS_DISABLE_IP_BLACKLIST to affect queries to matrix server itself.