### PR TITLE
Ensure the blacklist is skipped in all scenarios when UVS_DISABLE_IP_BLACKLIST: true

### DIFF
--- a/src/matrixUtils.js
+++ b/src/matrixUtils.js
@@ -51,11 +51,11 @@ function parseHostnameAndPort(serverName) {
  * @param {string} serverName       The server name to discover for
  * @returns {Promise<object>}       The homeserver discovery information
  */
-async function discoverHomeserverUrl(serverName) {
+async function discoverHomeserverUrl(serverName, disableBlacklistCheck = false) {
     let {hostname, port, defaultPort} = parseHostnameAndPort(serverName);
 
     // Don't continue if we consider the hostname part to resolve to our blacklisted IP ranges
-    if (utils.isBlacklisted(await utils.resolveDomain(hostname))) {
+    if (!disableBlacklistCheck && utils.isBlacklisted(await utils.resolveDomain(hostname))) {
         throw Error('Hostname resolves to a blacklisted IP range.');
     }
 
@@ -96,7 +96,7 @@ async function discoverHomeserverUrl(serverName) {
     let delegatedHostname;
     let response;
     try {
-        response = await utils.axiosGet(`https://${hostname}/.well-known/matrix/server`);
+        response = await utils.axiosGet(`https://${hostname}/.well-known/matrix/server`, null, {}, disableBlacklistCheck);
         delegatedHostname = response.data && response.data['m.server'];
     } catch (e) {
         // Pass

--- a/src/utils.js
+++ b/src/utils.js
@@ -188,7 +188,7 @@ async function axiosGet(url, haveRedirectedTimes = null, headers = null, disable
             // This was the fourth time following a redirect, abort
             throw new Error('Maximum amount of redirects reached.');
         }
-        return axiosGet(response.headers.location, redirects + 1, headers);
+        return axiosGet(response.headers.location, redirects + 1, headers, disableBlacklistCheck);
     }
     return response;
 }

--- a/src/verify.js
+++ b/src/verify.js
@@ -99,7 +99,7 @@ async function verifyOpenIDToken(req) {
         serverName = req.body.matrix_server_name;
     }
     try {
-        homeserver = await matrixUtils.discoverHomeserverUrl(serverName);
+        homeserver = await matrixUtils.discoverHomeserverUrl(serverName, process.env.UVS_DISABLE_IP_BLACKLIST === 'true');
     } catch (error) {
         logger.log('warn', `Failed to discover homeserver URL: ${error}`, {requestId: req.requestId});
         return false;
@@ -120,6 +120,7 @@ async function verifyOpenIDToken(req) {
             {
                 Host: homeserver.serverName,
             },
+            process.env.UVS_DISABLE_IP_BLACKLIST === 'true',
         );
     } catch (error) {
         utils.errorLogger(error, req);

--- a/tests/utils.tests.js
+++ b/tests/utils.tests.js
@@ -49,7 +49,7 @@ it('ensures redirection domain is not blacklisted', async() => {
                                                                  
     expect(raised).to.be.true;
     expect(axiosStub.calledOnce).to.be.true;
-    expect(axiosStub.calledTwice).to.be.false;
+    expect(axiosStub.calledTwice).to.be.true;
 });
 
         it('calls axios', async() => {


### PR DESCRIPTION
#22 unconditionally consulted the deny list for well-known lookups. It should also respect `UVS_DISABLE_IP_BLACKLIST: true`

Additionally the redirection test appeared to be testing exactly the opposite thing to what it said and would always consult the blacklist after the initial redirect.

That said IANAND (I am not a node developer) and haven't got an env run the tests in