### PR TITLE
Use system-level ca certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:22-slim
 
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY package*.json ./
@@ -12,4 +14,4 @@ ENV UVS_LISTEN_ADDRESS=0.0.0.0
 
 EXPOSE 3000
 
-CMD ["node", "src/app.js"]
+CMD ["node", "--use-openssl-ca", "src/app.js"]


### PR DESCRIPTION
This pull request makes minor updates to the `Dockerfile` to improve security and ensure proper certificate handling for Node.js.

* Security and certificate handling:
  * Added installation of `ca-certificates` in the Docker image to ensure secure HTTPS communication.
  * Changed the Node.js startup command to use the `--use-openssl-ca` flag, enabling Node.js to use system CA certificates for SSL connections.